### PR TITLE
17-bytes vlan

### DIFF
--- a/src/snail/comm_dev/comm_dev.c
+++ b/src/snail/comm_dev/comm_dev.c
@@ -1,4 +1,7 @@
 #include "comm_dev.h"
+#include "snail/checksum.h"
+#include "snail/escape.h"
+#include "snail/snail.h"
 
 struct comm_dev comm_dev;
 
@@ -52,97 +55,117 @@ prepare_pkg (struct pkg *pkg, pkg_t pkg_type, uint8_t *data, uint8_t size)
   pkg->size = size;
   pkg->sequence_number = seq++;
   pkg->type = pkg_type;
-  pkg->checksum = 0;
 
   memcpy (pkg->data, data, min (size, MAX_DATA));
+
+  pkg->checksum = calculate_checksum (pkg);
 
   return EXIT_SUCCESS;
 }
 
-int
-send_pkg (struct pkg *pkg, pkg_t pkg_type, uint8_t *data, uint8_t size)
+int send_pkg(struct pkg *pkg, pkg_t pkg_type, uint8_t *data, uint8_t size)
 {
   errno = 0;
+  int ret;
 
-  int ret = 0;
+  //Prepara o pacote com os dados e metadados
+  ret = prepare_pkg(pkg, pkg_type, data, size);
+  if (ret == EXIT_FAILURE) {
+    perror("Nao pode preparar pacote");
+    return EXIT_FAILURE;
+  }
 
-  ret = prepare_pkg (pkg, pkg_type, data, size);
-  if (ret == EXIT_FAILURE)
-    {
-      perror ("Nao pode prepara pacote: ");
-      return EXIT_FAILURE;
-    }
+  //Buffer para serialização e escape
+  uint8_t raw_buf[PKG_SIZE];
+  uint8_t escaped_buf[2 * PKG_SIZE]; // espaço extra para escapes
 
-  switch (comm_dev.comm_type)
-    {
+  //Serializa pacote -> raw_buf
+  size_t serialized_len = serialize_pkg(pkg, raw_buf);
+
+  //Aplica escape -> escaped_buf
+  int escaped_len = escape_bytes(raw_buf, serialized_len, escaped_buf);
+
+  //Envia pela rede conforme o tipo
+  switch (comm_dev.comm_type) {
     case BPF:
 #ifdef FREE_BSD
-      ret = write(comm_dev.fd, pkg, PKG_SIZE); 
-      printf("ret %d\n", ret);
-      if (ret == -1)
-        {
-          perror ("Nao pode enviar o pacote");
-          return EXIT_FAILURE;
-        }
+      ret = write(comm_dev.fd, escaped_buf, escaped_len);
+      if (ret == -1) {
+        perror("Nao pode enviar o pacote");
+        return EXIT_FAILURE;
+      }
 #endif
       break;
     case SOCKET:
 #ifdef LINUX
-      ret = send (comm_dev.fd, pkg, PKG_SIZE, 0);
-      if (ret == -1)
-        {
-          perror ("Nao pode enviar o pacote");
-          return EXIT_FAILURE;
-        }
+      ret = send(comm_dev.fd, escaped_buf, escaped_len, 0);
+      if (ret == -1) {
+        perror("Nao pode enviar o pacote");
+        return EXIT_FAILURE;
+      }
 #endif
       break;
-    }
+  }
 
   return EXIT_SUCCESS;
 }
 
-int
-recv_pkg (struct pkg *pkg)
+int recv_pkg(struct pkg *pkg)
 {
   errno = 0;
+  int ret;
 
-  int ret = 0;
+  //Buffer para leitura (máximo possível com escapes)
+  uint8_t escaped_buf[2 * PKG_SIZE];
+  uint8_t raw_buf[PKG_SIZE];
 
-  switch (comm_dev.comm_type)
-    {
+  int received_len = 0;
+
+  switch (comm_dev.comm_type) {
     case BPF:
 #ifdef FREE_BSD
       struct bpf_xhdr *bh;
       char *buf = malloc(BPF_BUF_SIZE);
-      if (!buf)
-      {
-        perror ("Nao pode alocar buffer para bpf: ");
+      if (!buf) {
+        perror("Nao pode alocar buffer para bpf");
         return EXIT_FAILURE;
       }
 
-      ret = read (comm_dev.fd, buf, BPF_BUF_SIZE);
+      ret = read(comm_dev.fd, buf, BPF_BUF_SIZE);
+      if (ret == -1) {
+        perror("Nao pode receber o pacote");
+        free(buf);
+        return EXIT_FAILURE;
+      }
+
       bh = (struct bpf_xhdr *)buf;
-
-      memcpy(pkg, buf + bh->bh_hdrlen , PKG_SIZE);  
-
-      if (ret == -1)
-        {
-          perror ("Nao pode receber o pacote");
-          return EXIT_FAILURE;
-        }
+      memcpy(escaped_buf, buf + bh->bh_hdrlen, ret - bh->bh_hdrlen);
+      received_len = ret - bh->bh_hdrlen;
+      free(buf);
 #endif
       break;
+
     case SOCKET:
 #ifdef LINUX
-      ret = recv (comm_dev.fd, pkg, PKG_SIZE, 0);
-      if (ret == -1)
-        {
-          perror ("Nao pode receber o pacote");
-          return EXIT_FAILURE;
-        }
+      ret = recv(comm_dev.fd, escaped_buf, sizeof(escaped_buf), 0);
+      if (ret == -1) {
+        perror("Nao pode receber o pacote");
+        return EXIT_FAILURE;
+      }
+      received_len = ret;
 #endif
       break;
-    }
+  }
+
+  //Remove escapes
+  int raw_len = unescape_bytes(escaped_buf, received_len, raw_buf);
+  if (raw_buf[0] != START_MARKER) {
+    fprintf(stderr, "Pacote ignorado: start_marker invalido (%d)\n", raw_buf[0]);
+    return EXIT_FAILURE;
+  }
+  
+  //Desserializa para a estrutura `pkg`
+  deserialize_pkg(pkg, raw_buf, raw_len);
 
   return EXIT_SUCCESS;
 }

--- a/src/snail/escape.c
+++ b/src/snail/escape.c
@@ -1,0 +1,28 @@
+#include "escape.h"
+
+int 
+escape_bytes (uint8_t *src, int len, uint8_t *dst) 
+{
+  int j = 0;
+  for (int i = 0; i < len; i++) 
+  {
+  	dst[j++] = src[i];
+    if (src[i] == VLAN_1 || src[i] == VLAN_2)
+      dst[j++] = ESCAPE_MARKER;
+  }
+  return j;
+}
+
+int 
+unescape_bytes (uint8_t *src, int len, uint8_t *dst) 
+{
+  int j = 0;
+  for (int i = 0; i < len; i++) 
+  {
+    dst[j++] = src[i];
+    if ((src[i] == VLAN_1 || src[i] == VLAN_2) 
+    		&& i + 1 < len && src[i + 1] == ESCAPE_MARKER)
+      i++; // pula o 0xFF
+  }
+  return j;
+}

--- a/src/snail/escape.h
+++ b/src/snail/escape.h
@@ -1,0 +1,13 @@
+#ifndef ESCAPE_H
+#define ESCAPE_H
+
+#include "pkg.h"
+#define VLAN_1 0x81
+#define VLAN_2 0x88
+#define ESCAPE_MARKER 0xFF
+
+int escape_bytes (uint8_t *src, int len, uint8_t *dst);
+
+int unescape_bytes (uint8_t *src, int len, uint8_t *dst);
+
+#endif

--- a/src/snail/snail.c
+++ b/src/snail/snail.c
@@ -13,7 +13,7 @@ init_snail (char network_interface[])
           min (strlen (network_interface), 64));
 
   /* Cria raw socket para comunicacao*/
-  ret = init_comm_dev (BPF, network_interface);
+  ret = init_comm_dev (SOCKET, network_interface);
   if (ret == EXIT_FAILURE)
     {
       perror ("Erro ao iniciar dispositivo de comunicação\n");
@@ -73,32 +73,31 @@ snail_recv ()
 size_t 
 serialize_pkg (const struct pkg *pkg, uint8_t *out_buf) 
 {
-  size_t i = 0;
-  
-  out_buf[i++] = pkg->start_marker;
-  out_buf[i++] = pkg->size & 0x7F;
-  out_buf[i++] = ((pkg->sequence_number & 0x1F) << 3) | (pkg->type & 0x0F);
-  out_buf[i++] = pkg->checksum;
-  
-  memcpy(&out_buf[i], pkg->data, pkg->size);
-  return i + pkg->size;
+  out_buf[0] = pkg->start_marker;
+  out_buf[1] = (pkg->size & 0x7F) | ((pkg->sequence_number & 0x01) << 7);
+  out_buf[2] = ((pkg->sequence_number >> 1) & 0x0F) << 4 | (pkg->type & 0x0F);
+  out_buf[3] = pkg->checksum;
+
+  memcpy(&out_buf[4], pkg->data, pkg->size);
+  return 4 + pkg->size;
 }
+
 
 /* Desserializa um buffer de bytes em uma estrutura de pacote */
 void 
 deserialize_pkg (struct pkg *pkg, const uint8_t *in_buf, size_t len) 
 {
-  size_t i = 0;
-  
-  pkg->start_marker = in_buf[i++];
-  pkg->size = in_buf[i++] & 0x7F;
-  
-  uint8_t seq_type = in_buf[i++];
-  
-  pkg->sequence_number = (seq_type >> 3) & 0x1F;
-  pkg->type = seq_type & 0x0F;
-  pkg->checksum = in_buf[i++];
-  
+  pkg->start_marker = in_buf[0];
+  pkg->size = in_buf[1] & 0x7F;
+
+  uint8_t seq_lo = (in_buf[1] >> 7) & 0x01;
+  uint8_t seq_hi = (in_buf[2] >> 4) & 0x0F;
+  pkg->sequence_number = (seq_hi << 1) | seq_lo;
+
+  pkg->type = in_buf[2] & 0x0F;
+  pkg->checksum = in_buf[3];
+
   memset(pkg->data, 0, MAX_DATA);
-  memcpy(pkg->data, &in_buf[i], pkg->size);
+  memcpy(pkg->data, &in_buf[4], pkg->size);
 }
+

--- a/src/snail/snail.h
+++ b/src/snail/snail.h
@@ -19,4 +19,10 @@ int snail_send (pkg_t pkg_type, char *data, uint8_t size);
 
 int snail_recv ();
 
+size_t serialize_pkg (const struct pkg *pkg, uint8_t *out_buf);
+
+void deserialize_pkg (struct pkg *pkg, const uint8_t *in_buf, size_t len);
+
+
+
 #endif


### PR DESCRIPTION
possível uso em send_pkg:
```
int send_pkg(struct pkg *pkg, pkg_t pkg_type, uint8_t *data, uint8_t size)
{
  errno = 0;
  int ret;

  //Prepara o pacote com os dados e metadados
  ret = prepare_pkg(pkg, pkg_type, data, size);
  if (ret == EXIT_FAILURE) {
    perror("Nao pode preparar pacote");
    return EXIT_FAILURE;
  }

  //Buffer para serialização e escape
  uint8_t raw_buf[PKG_SIZE];
  uint8_t escaped_buf[2 * PKG_SIZE]; // espaço extra para escapes

  //Serializa pacote -> raw_buf
  size_t serialized_len = serialize_pkg(pkg, raw_buf);

  //Aplica escape -> escaped_buf
  int escaped_len = escape_bytes(raw_buf, serialized_len, escaped_buf);

  //Envia pela rede conforme o tipo
  switch (comm_dev.comm_type) {
    case BPF:
#ifdef FREE_BSD
      ret = write(comm_dev.fd, escaped_buf, escaped_len);
      if (ret == -1) {
        perror("Nao pode enviar o pacote");
        return EXIT_FAILURE;
      }
#endif
      break;
    case SOCKET:
#ifdef LINUX
      ret = send(comm_dev.fd, escaped_buf, escaped_len, 0);
      if (ret == -1) {
        perror("Nao pode enviar o pacote");
        return EXIT_FAILURE;
      }
#endif
      break;
  }

  return EXIT_SUCCESS;
}
```
possível uso em recv_pkg:
```
int recv_pkg(struct pkg *pkg)
{
  errno = 0;
  int ret;

  //Buffer para leitura (máximo possível com escapes)
  uint8_t escaped_buf[2 * PKG_SIZE];
  uint8_t raw_buf[PKG_SIZE];

  int received_len = 0;

  switch (comm_dev.comm_type) {
    case BPF:
#ifdef FREE_BSD
      struct bpf_xhdr *bh;
      char *buf = malloc(BPF_BUF_SIZE);
      if (!buf) {
        perror("Nao pode alocar buffer para bpf");
        return EXIT_FAILURE;
      }

      ret = read(comm_dev.fd, buf, BPF_BUF_SIZE);
      if (ret == -1) {
        perror("Nao pode receber o pacote");
        free(buf);
        return EXIT_FAILURE;
      }

      bh = (struct bpf_xhdr *)buf;
      memcpy(escaped_buf, buf + bh->bh_hdrlen, ret - bh->bh_hdrlen);
      received_len = ret - bh->bh_hdrlen;
      free(buf);
#endif
      break;

    case SOCKET:
#ifdef LINUX
      ret = recv(comm_dev.fd, escaped_buf, sizeof(escaped_buf), 0);
      if (ret == -1) {
        perror("Nao pode receber o pacote");
        return EXIT_FAILURE;
      }
      received_len = ret;
#endif
      break;
  }

  //Remove escapes
  int raw_len = unescape_bytes(escaped_buf, received_len, raw_buf);

  //Desserializa para a estrutura `pkg`
  deserialize_pkg(pkg, raw_buf, raw_len);

  return EXIT_SUCCESS;
}
```
